### PR TITLE
cyclic dependencies issue

### DIFF
--- a/src/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/src/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -35,6 +35,8 @@ internal class IonSchemaSystemImpl(
 ) : IonSchemaSystem {
 
     private val schemaCore = SchemaCore(this)
+    // Set to be used to detect cycle in import dependencies
+    private val schemaImportSet: MutableSet<String> = mutableSetOf<String>()
 
     override fun loadSchema(id: String) =
         schemaCache.getOrPut(id) {
@@ -71,6 +73,15 @@ internal class IonSchemaSystemImpl(
             = constraintFactory.constraintFor(ion, schema)
 
     internal fun getIonSystem() = ION
+
+    internal fun resetSchemaImportSet(id: String, parent_id: String) {
+        schemaImportSet.remove(id)
+        schemaImportSet.remove(parent_id)
+    }
+
+    internal fun addToSchemaImportSet(id: String) = schemaImportSet.add(id)
+
+    internal fun getSchemaImportSet() = schemaImportSet;
 
     internal fun hasParam(param: Param) = params.containsKey(param)
 


### PR DESCRIPTION
*Description of changes:*
This is a draft PR for [#58](https://github.com/amzn/ion-schema-kotlin/issues/58). 

**Tasks:**
1. Added `schemaImportSet` in `IonSchemaSystemImpl` to store all imports in order to detect cycle.
2. In `schemaImportSet` added  2 new variables `nocycle`(stores whether cycle exists or not) and  `normalizedId`(stores a normalized schema Id with path of the schema to be imported)
3. Throws error if schema tries to import itself.
4.  `loadHeader` if cycle is detected will not load schema again to break the dependency/import cycle.
